### PR TITLE
Use unittest.main to run tests for correct exit code

### DIFF
--- a/test_vobject.py
+++ b/test_vobject.py
@@ -24,7 +24,7 @@ def additional_tests():
 
 if __name__ == '__main__':
     runner = unittest.TextTestRunner()
-    runner.run(additional_tests())
+    unittest.main(testRunner=runner)
 
 
 testSilly="""


### PR DESCRIPTION
When running the TestRunner instance directly, the script would report
failures to std{out,err} but exit with a success status despite test
failures, c.f.
https://travis-ci.org/tBaxter/vobject/jobs/44978065#L859-L859:

```
FAILED (failures=26)
The command "python test_vobject.py additional_tests" exited with 0.
```

Using `unittest.main`, things Should Just Work
