### PR TITLE
fix some print statements and opening files when preferred encoding != utf8

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -6,6 +6,7 @@ import dateutil
 import re
 import unittest
 import io
+import sys
 
 from dateutil.tz import tzutc
 from dateutil.rrule import rrule, rruleset, WEEKLY, MONTHLY
@@ -28,7 +29,13 @@ def get_test_file(path):
     Helper function to open and read test files.
     """
     filepath = "test_files/{}".format(path)
-    f = io.open(filepath, 'r', encoding='utf-8')
+    if sys.version_info[0] < 3:
+        # On python 2, this library operates on bytes.
+        f = open(filepath, 'r')
+    else:
+        # On python 3, it operates on unicode. We need to specify an encoding for systems
+        # for which the preferred encoding isn't utf-8 (e.g windows).
+        f = open(filepath, 'r', encoding='utf-8')
     text = f.read()
     f.close()
     return text

--- a/tests.py
+++ b/tests.py
@@ -3,10 +3,10 @@ from __future__ import print_function
 
 import datetime
 import dateutil
-import re
-import unittest
 import io
+import re
 import sys
+import unittest
 
 from dateutil.tz import tzutc
 from dateutil.rrule import rrule, rruleset, WEEKLY, MONTHLY
@@ -17,6 +17,8 @@ from vobject import icalendar
 from vobject.base import __behaviorRegistry as behavior_registry
 from vobject.base import ContentLine, parseLine, ParseError
 from vobject.base import readComponents, textLineToContentLine
+
+from vobject.change_tz import change_tz
 
 from vobject.icalendar import MultiDateBehavior, PeriodBehavior, RecurringComponent, utc
 from vobject.icalendar import parseDtstart, stringToTextValues, stringToPeriod, timedeltaToString
@@ -594,6 +596,112 @@ class TestIcalendar(unittest.TestCase):
             list(vevent.getrruleset(True)),
             [datetime.datetime(2005, 3, 18, 0, 0), datetime.datetime(2005, 3, 29, 0, 0)]
         )
+
+
+class TestChangeTZ(unittest.TestCase):
+    """Tests for change_tz.change_tz"""
+
+    class StubCal(object):
+        class StubEvent(object):
+            class Node(object):
+                def __init__(self, value):
+                    self.value = value
+
+            def __init__(self, dtstart, dtend):
+                self.dtstart = self.Node(dtstart)
+                self.dtend = self.Node(dtend)
+
+        def __init__(self, dates):
+            """ dates is a list of tuples (dtstart, dtend) """
+            self.vevent_list = [self.StubEvent(*d) for d in dates]
+
+    def test_change_tz(self):
+        """Change the timezones of events in a component to a different
+        timezone"""
+
+        # Setup - create a stub vevent list
+        old_tz = dateutil.tz.gettz('UTC')  # 0:00
+        new_tz = dateutil.tz.gettz('America/Chicago')  # -5:00
+
+        dates = [
+            (datetime.datetime(1999, 12, 31, 23, 59, 59, 0, tzinfo=old_tz),
+             datetime.datetime(2000, 1, 1, 0, 0, 0, 0, tzinfo=old_tz)),
+            (datetime.datetime(2010, 12, 31, 23, 59, 59, 0, tzinfo=old_tz),
+             datetime.datetime(2011, 1, 2, 3, 0, 0, 0, tzinfo=old_tz))]
+
+        cal = self.StubCal(dates)
+
+        # Exercise - change the timezone
+        change_tz(cal, new_tz, dateutil.tz.gettz('UTC'))
+
+        # Test - that the tzs were converted correctly
+        expected_new_dates = [
+            (datetime.datetime(1999, 12, 31, 17, 59, 59, 0, tzinfo=new_tz),
+             datetime.datetime(1999, 12, 31, 18, 0, 0, 0, tzinfo=new_tz)),
+            (datetime.datetime(2010, 12, 31, 17, 59, 59, 0, tzinfo=new_tz),
+             datetime.datetime(2011, 1, 1, 21, 0, 0, 0, tzinfo=new_tz))]
+
+        for vevent, expected_datepair in zip(cal.vevent_list,
+                                             expected_new_dates):
+            self.assertEqual(vevent.dtstart.value, expected_datepair[0])
+            self.assertEqual(vevent.dtend.value, expected_datepair[1])
+
+    def test_change_tz_utc_only(self):
+        """Change any UTC timezones of events in a component to a different
+        timezone"""
+
+        # Setup - create a stub vevent list
+        utc_tz = dateutil.tz.gettz('UTC')  # 0:00
+        non_utc_tz = dateutil.tz.gettz('America/Santiago')  # -4:00
+        new_tz = dateutil.tz.gettz('America/Chicago')  # -5:00
+
+        dates = [
+            (datetime.datetime(1999, 12, 31, 23, 59, 59, 0, tzinfo=utc_tz),
+             datetime.datetime(2000, 1, 1, 0, 0, 0, 0, tzinfo=non_utc_tz))]
+
+        cal = self.StubCal(dates)
+
+        # Exercise - change the timezone passing utc_only=True
+        change_tz(cal, new_tz, dateutil.tz.gettz('UTC'), utc_only=True)
+
+        # Test - that only the utc item has changed
+        expected_new_dates = [
+            (datetime.datetime(1999, 12, 31, 17, 59, 59, 0, tzinfo=new_tz),
+             dates[0][1])]
+
+        for vevent, expected_datepair in zip(cal.vevent_list,
+                                             expected_new_dates):
+            self.assertEqual(vevent.dtstart.value, expected_datepair[0])
+            self.assertEqual(vevent.dtend.value, expected_datepair[1])
+
+    def test_change_tz_default(self):
+        """Change the timezones of events in a component to a different
+        timezone, passing a default timezone that is assumed when the events
+        don't have one"""
+
+        # Setup - create a stub vevent list
+        old_tz = dateutil.tz.gettz('UTC')  # 0:00
+        new_tz = dateutil.tz.gettz('America/Chicago')  # -5:00
+
+        dates = [
+            (datetime.datetime(1999, 12, 31, 23, 59, 59, 0, tzinfo=None),
+             datetime.datetime(2000, 1, 1, 0, 0, 0, 0, tzinfo=None))]
+
+        cal = self.StubCal(dates)
+
+        # Exercise - change the timezone
+        change_tz(cal, new_tz, dateutil.tz.gettz('UTC'))
+
+        # Test - that the tzs were converted correctly
+        expected_new_dates = [
+            (datetime.datetime(1999, 12, 31, 17, 59, 59, 0, tzinfo=new_tz),
+             datetime.datetime(1999, 12, 31, 18, 0, 0, 0, tzinfo=new_tz))]
+
+        for vevent, expected_datepair in zip(cal.vevent_list,
+                                             expected_new_dates):
+            self.assertEqual(vevent.dtstart.value, expected_datepair[0])
+            self.assertEqual(vevent.dtend.value, expected_datepair[1])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -5,6 +5,7 @@ import datetime
 import dateutil
 import re
 import unittest
+import io
 
 from dateutil.tz import tzutc
 from dateutil.rrule import rrule, rruleset, WEEKLY, MONTHLY
@@ -27,7 +28,7 @@ def get_test_file(path):
     Helper function to open and read test files.
     """
     filepath = "test_files/{}".format(path)
-    f = open(filepath, 'r')
+    f = io.open(filepath, 'r', encoding='utf-8')
     text = f.read()
     f.close()
     return text

--- a/vobject/change_tz.py
+++ b/vobject/change_tz.py
@@ -28,31 +28,32 @@ def change_tz(cal, new_timezone, default, utc_only=False, utc_tz=icalendar.utc):
 def main():
     options, args = get_options()
     if PyICU is None:
-        print "Failure. change_tz requires PyICU, exiting"
+        print("Failure. change_tz requires PyICU, exiting")
     elif options.list:
         for tz_string in PyICU.TimeZone.createEnumeration():
-            print tz_string
+            print(tz_string)
     elif args:
         utc_only = options.utc
         if utc_only:
             which = "only UTC"
         else:
             which = "all"
-        print "Converting %s events" % which
+        print("Converting %s events" % which)
         ics_file = args[0]
         if len(args) > 1:
             timezone = PyICU.ICUtzinfo.getInstance(args[1])
         else:
             timezone = PyICU.ICUtzinfo.default
-        print "... Reading %s" % ics_file
+        print("... Reading %s" % ics_file)
         cal = base.readOne(file(ics_file))
         change_tz(cal, timezone, PyICU.ICUtzinfo.default, utc_only)
 
         out_name = ics_file + '.converted'
-        print "... Writing %s" % out_name
+        print("... Writing %s" % out_name)
+
         out = file(out_name, 'wb')
         cal.serialize(out)
-        print "Done"
+        print("Done")
 
 
 version = "0.1"
@@ -72,9 +73,9 @@ def get_options():
 
     (cmdline_options, args) = parser.parse_args()
     if not args and not cmdline_options.list:
-        print "error: too few arguments given"
-        print
-        print parser.format_help()
+        print("error: too few arguments given")
+        print()
+        print(parser.format_help())
         return False, False
 
     return cmdline_options, args
@@ -83,4 +84,4 @@ if __name__ == "__main__":
     try:
         main()
     except KeyboardInterrupt:
-        print "Aborted"
+        print("Aborted")

--- a/vobject/change_tz.py
+++ b/vobject/change_tz.py
@@ -13,6 +13,18 @@ except:
 from datetime import datetime
 
 def change_tz(cal, new_timezone, default, utc_only=False, utc_tz=icalendar.utc):
+    """Change the timezone of the specified component.
+
+    Args:
+        cal (Component): the component to change
+        new_timezone (tzinfo): the timezone to change to
+        default (tzinfo): a timezone to assume if the dtstart or dtend in cal 
+            doesn't have an existing timezone
+        utc_only (bool): only convert dates that are in utc
+        utc_tz (tzinfo): the tzinfo to compare to for UTC when processing 
+            utc_only=True
+    """
+
     for vevent in getattr(cal, 'vevent_list', []):
         start = getattr(vevent, 'dtstart', None)
         end   = getattr(vevent, 'dtend',   None)
@@ -20,7 +32,7 @@ def change_tz(cal, new_timezone, default, utc_only=False, utc_tz=icalendar.utc):
             if node:
                 dt = node.value
                 if (isinstance(dt, datetime) and
-                    (not utc_only or dt.tzinfo == utc_tz)):
+                        (not utc_only or dt.tzinfo == utc_tz)):
                     if dt.tzinfo is None:
                         dt = dt.replace(tzinfo = default)
                     node.value = dt.astimezone(new_timezone)
@@ -45,7 +57,7 @@ def main():
         else:
             timezone = PyICU.ICUtzinfo.default
         print("... Reading %s" % ics_file)
-        cal = base.readOne(file(ics_file))
+        cal = base.readOne(open(ics_file))
         change_tz(cal, timezone, PyICU.ICUtzinfo.default, utc_only)
 
         out_name = ics_file + '.converted'


### PR DESCRIPTION
As titled. And - your work is very much appreciated, I need this lib to work on python 3!

Some feedback:

I'm not sure that having the lib operating on two different string types in the different python versions is going to be the easiest thing to maintain going forward - it might be easier to have it always operate on bytes internally (i.e. preserve the py2 behaviour) and always return unicode strings to callers. This would also prove consistency to multi-version callers.