### PR TITLE
Bugfix: folded lines missing indentation

### DIFF
--- a/test_files/journal.ics
+++ b/test_files/journal.ics
@@ -1,0 +1,15 @@
+BEGIN:VJOURNAL
+UID:19970901T130000Z-123405@example.com
+DTSTAMP:19970901T130000Z
+DTSTART;VALUE=DATE:19970317
+SUMMARY:Staff meeting minutes
+DESCRIPTION:1. Staff meeting: Participants include Joe\,
+  Lisa\, and Bob. Aurora project plans were reviewed.
+  There is currently no budget reserves for this project.
+  Lisa will escalate to management. Next meeting on Tuesday.\n
+ 2. Telephone Conference: ABC Corp. sales representative
+  called to discuss new printer. Promised to get us a demo by
+  Friday.\n3. Henry Miller (Handsoff Insurance): Car was
+  totaled by tree. Is looking into a loaner car. 555-2323
+  (tel).
+END:VJOURNAL

--- a/tests.py
+++ b/tests.py
@@ -71,6 +71,17 @@ class TestCalendarSerializing(unittest.TestCase):
             'The title こんにちはキティ'
         )
 
+    def test_wrapping(self):
+        """
+        Should support an input file with a long text field covering multiple lines
+        """
+        test_journal = get_test_file("journal.ics")
+        vobj = base.readOne(test_journal)
+        vjournal = base.readOne(vobj.serialize()).vjournal
+        self.assertTrue('Joe, Lisa and Bob' in vjournal.description.value)
+        self.assertTrue('Tuesday.\n2.' in vjournal.description.value)
+        
+
     def test_multiline(self):
         """
         Multi-text serialization test

--- a/tests.py
+++ b/tests.py
@@ -80,7 +80,6 @@ class TestCalendarSerializing(unittest.TestCase):
         vjournal = base.readOne(vobj.serialize())
         self.assertTrue('Joe, Lisa, and Bob' in vjournal.description.value)
         self.assertTrue('Tuesday.\n2.' in vjournal.description.value)
-        
 
     def test_multiline(self):
         """

--- a/tests.py
+++ b/tests.py
@@ -77,8 +77,8 @@ class TestCalendarSerializing(unittest.TestCase):
         """
         test_journal = get_test_file("journal.ics")
         vobj = base.readOne(test_journal)
-        vjournal = base.readOne(vobj.serialize()).vjournal
-        self.assertTrue('Joe, Lisa and Bob' in vjournal.description.value)
+        vjournal = base.readOne(vobj.serialize())
+        self.assertTrue('Joe, Lisa, and Bob' in vjournal.description.value)
         self.assertTrue('Tuesday.\n2.' in vjournal.description.value)
         
 

--- a/vobject/base.py
+++ b/vobject/base.py
@@ -920,11 +920,11 @@ def foldOneLine(outbuf, input, lineLength = 75):
                 line = input[start:offset]
                 try:
                     outbuf.write(bytes(line, 'UTF-8'))
-                    outbuf.write(bytes("\r\n", 'UTF-8'))
+                    outbuf.write(bytes("\r\n ", 'UTF-8'))
                 except Exception:
                     # fall back on py2 syntax
                     outbuf.write(line)
-                    outbuf.write("\r\n")
+                    outbuf.write("\r\n ")
                 written += offset - start
                 start = offset
     try:


### PR DESCRIPTION
Hi,

I ran into a bug, your fork of version of vobject wasn't able to parse, serialize and re-parse an example from the RFC.  (it apparently works with the old vobject version though).