### PR TITLE
Python 3 timezone declaration fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 
+__pycache__
+
 vobject.egg-info/PKG-INFO
 
 vobject.egg-info/SOURCES.txt
@@ -12,11 +14,3 @@ vobject.egg-info/requires.txt
 vobject.egg-info/top_level.txt
 
 vobject.egg-info/zip-safe
-
-vobject/__pycache__/__init__.cpython-33.pyc
-
-vobject/__pycache__/base.cpython-33.pyc
-
-vobject/__pycache__/behavior.cpython-33.pyc
-
-vobject/__pycache__/icalendar.cpython-33.pyc

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ from setuptools import setup, find_packages
 doclines = __doc__.splitlines()
 
 setup(name="vobject",
-      version="0.8.5",
+      version="0.8.6",
       author="Jeffrey Harris, Tim Baxter",
       author_email="mail.baxter@gmail.com",
       license="Apache",

--- a/vobject/icalendar.py
+++ b/vobject/icalendar.py
@@ -1550,7 +1550,7 @@ def dateTimeToString(dateTime, convertToUTC=False):
 
 def deltaToOffset(delta):
     absDelta = abs(delta)
-    hours = absDelta.seconds / 3600
+    hours = int(absDelta.seconds / 3600)
     hoursString      = numToDigits(hours, 2)
     minutesString    = '00'
     if absDelta == delta:


### PR DESCRIPTION
Hello,

I made only one modification to the code for Python 3:
* - hours = absDelta.seconds / 3600
* + hours = int(absDelta.seconds / 3600)

I think this do not alter the way it works when using Python 2.

Regards,
Stéphane Diemer